### PR TITLE
Create copies of received messages to avid race conditions by threading overwriting message buffer references

### DIFF
--- a/Masterloop.Plugin.Application.sln
+++ b/Masterloop.Plugin.Application.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{537ED9AA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Masterloop.Plugin.Application.Tests", "tests\Masterloop.Plugin.Application.Tests\Masterloop.Plugin.Application.Tests.csproj", "{DF108B47-5E80-4CC4-A87D-2FA41B5783AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Masterloop.Plugin.Application.LongTests", "tests\Masterloop.Plugin.Application.LongTests\Masterloop.Plugin.Application.LongTests.csproj", "{93A2373E-47DA-47C0-9714-042AE37268CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,11 +39,16 @@ Global
 		{DF108B47-5E80-4CC4-A87D-2FA41B5783AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF108B47-5E80-4CC4-A87D-2FA41B5783AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF108B47-5E80-4CC4-A87D-2FA41B5783AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93A2373E-47DA-47C0-9714-042AE37268CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93A2373E-47DA-47C0-9714-042AE37268CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93A2373E-47DA-47C0-9714-042AE37268CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93A2373E-47DA-47C0-9714-042AE37268CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DEDBC216-7FCB-404C-8F21-9EC54BCFD823} = {610369E7-0EA7-40AF-BFAD-700068BAF04F}
 		{603AEB9C-5201-4EC2-8A57-05DC88210132} = {50FD4255-A765-4553-8E4F-90A3A91EED0B}
 		{DF108B47-5E80-4CC4-A87D-2FA41B5783AC} = {537ED9AA-74DB-427C-95D3-81BD84563C3A}
+		{93A2373E-47DA-47C0-9714-042AE37268CB} = {537ED9AA-74DB-427C-95D3-81BD84563C3A}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		version = 6.3.1-rc

--- a/src/Masterloop.Plugin.Application/Masterloop.Plugin.Application.csproj
+++ b/src/Masterloop.Plugin.Application/Masterloop.Plugin.Application.csproj
@@ -23,6 +23,7 @@
     <ReleaseVersion>6.3.1-rc</ReleaseVersion>
     <PackageIconUrl>http://masterloop.azurewebsites.net/Images/Masterloop_Symbol_Square_32x32.png</PackageIconUrl>
     <PackageLicenseUrl>http://masterloop.azurewebsites.net/Licenses/masterloop-mit-license.txt</PackageLicenseUrl>
+    <Configurations>Release;Debug</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType></DebugType>

--- a/src/Masterloop.Plugin.Application/MasterloopLiveConnection.cs
+++ b/src/Masterloop.Plugin.Application/MasterloopLiveConnection.cs
@@ -185,7 +185,7 @@ namespace Masterloop.Plugin.Application
         public string LastErrorMessage { get; set; }
 
         /// <summary>
-        /// Last fetch message routing key as text string.
+        /// Last fetched message routing key as text string.
         /// </summary>
         public string LastFetchedMessageRoutingKey
         {
@@ -496,7 +496,10 @@ namespace Masterloop.Plugin.Application
                     _lastFetchedMessageRoutingKey = message.RoutingKey;
                     _lastFetchedMessageBody = Encoding.UTF8.GetString(message.Body.Span);
                 }
-                catch (Exception) { }
+                catch (Exception e)
+                {
+                    LastErrorMessage = e.Message;
+                }
                 return Dispatch(message.RoutingKey, GetMessageHeader(message), message.BodyBuffer, message.DeliveryTag);
             }
 

--- a/tests/Masterloop.Plugin.Application.LongTests/Masterloop.Plugin.Application.LongTests.csproj
+++ b/tests/Masterloop.Plugin.Application.LongTests/Masterloop.Plugin.Application.LongTests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Masterloop.Plugin.Application\Masterloop.Plugin.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Masterloop.Plugin.Application.LongTests/ObservationSubscriber.cs
+++ b/tests/Masterloop.Plugin.Application.LongTests/ObservationSubscriber.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading;
+using Masterloop.Core.Types.Base;
+using Masterloop.Core.Types.LiveConnect;
+using Masterloop.Core.Types.Observations;
+
+namespace Masterloop.Plugin.Application.LongTests
+{
+    public class ObservationSubscriber
+    {
+        IMasterloopLiveConnection _live;
+        LiveAppRequest _lar; 
+
+        public ObservationSubscriber(string hostname, string username, string password, bool useEncryption)
+        {
+            _live = new MasterloopLiveConnection(hostname, username, password, useEncryption);
+            _live.UseAutomaticCallbacks = false;
+            _lar = new LiveAppRequest()
+            {
+                TID = "",
+                ConnectAllObservations = true
+            };
+        }
+
+        public bool Init()
+        {
+            _live.RegisterObservationHandler(null, 2, OnObservationReceived, DataType.Boolean);
+            _live.RegisterObservationHandler(null, 3, OnObservationReceived, DataType.Double);
+            _live.RegisterObservationHandler(null, 4, OnObservationReceived, DataType.Integer);
+            _live.RegisterObservationHandler(null, 5, OnObservationReceived, DataType.Position);
+            _live.RegisterObservationHandler(null, 6, OnObservationReceived, DataType.String);
+            _live.RegisterObservationHandler(null, 7, OnObservationReceived, DataType.Statistics);
+            return _live.Connect(new LiveAppRequest[] { _lar });
+        }
+
+        public void Run()
+        {
+            while (true)
+            {
+                if (!_live.IsConnected())
+                {
+                    if (!_live.Connect())
+                    {
+                        Thread.Sleep(5000);
+                    }
+                }
+                if (_live.QueueCount > 0)
+                {
+                    Console.WriteLine($"{_live.QueueCount} messages in queue.");
+                }
+                while (_live.QueueCount > 0)
+                {
+                    _live.Fetch();
+                }
+                Thread.Sleep(1);
+            }
+        }
+
+        private void OnObservationReceived(string mid, int observationId, Observation o)
+        {
+            Console.WriteLine($"{mid} received obsId={observationId} with timestamp {o.Timestamp:O}");
+        }
+    }
+}

--- a/tests/Masterloop.Plugin.Application.LongTests/Program.cs
+++ b/tests/Masterloop.Plugin.Application.LongTests/Program.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Masterloop.Plugin.Application.LongTests
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Masterloop.Plugin.Application.LongTests");
+            ObservationSubscriber oSub = new ObservationSubscriber("", "", "", true);
+            if (oSub.Init())
+            {
+                oSub.Run();
+            }
+        }
+    }
+}

--- a/tests/Masterloop.Plugin.Application.Tests/Masterloop.Plugin.Application.Tests.csproj
+++ b/tests/Masterloop.Plugin.Application.Tests/Masterloop.Plugin.Application.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="3.0.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
@@ -21,5 +21,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Masterloop.Plugin.Application\Masterloop.Plugin.Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="appsettings.test.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="appsettings.test.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/tests/Masterloop.Plugin.Application.Tests/appsettings.test.json
+++ b/tests/Masterloop.Plugin.Application.Tests/appsettings.test.json
@@ -1,0 +1,9 @@
+﻿{
+  "Hostname": "",
+  "Username": "",
+  "Password": "",
+  "UseHTTPS": true,
+  "MID": "",
+  "TID": "",
+  "PersistentSubscriptionKey": ""
+}


### PR DESCRIPTION
This is a proposed fix for #12

A new local datatype is introduced that buffers the referenced memory in a local byte array for processing. This branch creates explicit copies of the data, so it will be slower than the source implementation, but threaded queue handling is possible and the plugin does not frequently fail internally when PrefetchCount != 1 and AutoAck == false.