### PR TITLE
Adding exception handling if local network interfaces are not accessible

### DIFF
--- a/src/Masterloop.Plugin.Application/MasterloopLiveConnection.cs
+++ b/src/Masterloop.Plugin.Application/MasterloopLiveConnection.cs
@@ -1190,16 +1190,24 @@ namespace Masterloop.Plugin.Application
 
         private string GetLocalIPAddress()
         {
-            if (NetworkInterface.GetIsNetworkAvailable())
+            try
             {
-                var host = Dns.GetHostEntry(Dns.GetHostName());
-                foreach (var ip in host.AddressList)
+
+                if (NetworkInterface.GetIsNetworkAvailable())
                 {
-                    if (ip.AddressFamily == AddressFamily.InterNetwork)
+                    var host = Dns.GetHostEntry(Dns.GetHostName());
+                    foreach (var ip in host.AddressList)
                     {
-                        return ip.ToString();
+                        if (ip.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            return ip.ToString();
+                        }
                     }
                 }
+            }
+            catch (NetworkInformationException)
+            {
+                // Running on platform where LocalIP is not available
             }
             return null;
         }

--- a/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
+++ b/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
@@ -1512,16 +1512,24 @@ namespace Masterloop.Plugin.Application
 
         private string GetLocalIPAddress()
         {
-            if (NetworkInterface.GetIsNetworkAvailable())
+            try
             {
-                var host = Dns.GetHostEntry(Dns.GetHostName());
-                foreach (var ip in host.AddressList)
+
+                if (NetworkInterface.GetIsNetworkAvailable())
                 {
-                    if (ip.AddressFamily == AddressFamily.InterNetwork)
+                    var host = Dns.GetHostEntry(Dns.GetHostName());
+                    foreach (var ip in host.AddressList)
                     {
-                        return ip.ToString();
+                        if (ip.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            return ip.ToString();
+                        }
                     }
                 }
+            }
+            catch (NetworkInformationException)
+            {
+                // Running on platform where LocalIP is not available
             }
             return null;
         }


### PR DESCRIPTION
This is a proposed fix for #15 

If a NetworkInformationException is raised, behave the same way as if the normal DNS lookup fails