### PR TITLE
add template variant endpoint to REST api connection

### DIFF
--- a/src/Masterloop.Plugin.Application/Masterloop.Plugin.Application.csproj
+++ b/src/Masterloop.Plugin.Application/Masterloop.Plugin.Application.csproj
@@ -31,6 +31,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
-    <PackageReference Include="Masterloop.Core.Types" Version="6.3.0" />
+    <PackageReference Include="Masterloop.Core.Types" Version="6.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
+++ b/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
@@ -53,6 +53,8 @@ namespace Masterloop.Plugin.Application
         private const string _addressDeviceSettingsExpanded = "/api/devices/{0}/settings/expanded";
         private const string _addressDeviceLatestActivityTimestamp = "/api/devices/{0}/activity/latest/timestamp";
         private const string _addressDeviceTemplateFirmwareCurrent = "/api/templates/{0}/firmware/current";
+        private const string _addressDeviceTemplateFirmwareVariants = "/api/templates/{0}/firmware/variants";
+        private const string _addressDeviceTemplateFirmwareVariantsCurrent = "/api/templates/{0}/firmware/{1}/current";
         private const string _addressToolsLiveConnect = "/api/tools/liveconnect";
         private const string _addressToolsLiveConnectTemporaryIdentified = "/api/tools/liveconnect/{0}";
         private const string _addressToolsLiveConnectPersistent = "/api/tools/liveconnect/persistent";
@@ -477,6 +479,54 @@ namespace Masterloop.Plugin.Application
             string url = string.Format(_addressDeviceTemplateFirmwareCurrent, TID);
             return await GetDeserializedAsync<FirmwareReleaseDescriptor>(url);
         }
+
+        /// <summary>
+        /// Get firmware variants for template.
+        /// </summary>
+        /// <param name="TID">Template identifier.</param>
+        /// <returns>Firmware variant information.</returns>
+        public FirmwareVariant[] GetDeviceTemplateFirmwareVariants(string TID)
+        {
+            string url = string.Format(_addressDeviceTemplateFirmwareVariants, TID);
+            return GetDeserialized<FirmwareVariant[]>(url);
+        }
+
+        /// <summary>
+        /// Get firmware variants for template.
+        /// </summary>
+        /// <param name="TID">Template identifier.</param>
+        /// <returns>Firmware variant information.</returns>
+        public async Task<FirmwareVariant[]> GetDeviceTemplateFirmwareVariantsAsync(string TID)
+        {
+            string url = string.Format(_addressDeviceTemplateFirmwareVariants, TID);
+            return await GetDeserializedAsync<FirmwareVariant[]>(url);
+        }
+
+        /// <summary>
+        /// Get current firmware details for template firmware variant.
+        /// </summary>
+        /// <param name="TID">Template identifier.</param>
+        /// <param name="firmwareVariantId">Variant identifier.</param>
+        /// <returns>Firmware release information.</returns>
+        public FirmwareReleaseDescriptor GetCurrentDeviceTemplateVariantFirmwareDetails(string TID, int firmwareVariantId)
+        {
+            string url = string.Format(_addressDeviceTemplateFirmwareVariantsCurrent, TID, firmwareVariantId);
+            return GetDeserialized<FirmwareReleaseDescriptor>(url);
+        }
+
+        /// <summary>
+        /// Get current firmware details for template firmware variant.
+        /// </summary>
+        /// <param name="TID">Template identifier.</param>
+        /// <param name="firmwareVariantId">Variant identifier.</param>
+        /// <returns>Firmware release information.</returns>
+        public async Task<FirmwareReleaseDescriptor> GetCurrentDeviceTemplateVariantFirmwareDetailsAsync(string TID, int firmwareVariantId)
+        {
+            string url = string.Format(_addressDeviceTemplateFirmwareVariantsCurrent, TID, firmwareVariantId);
+            return await GetDeserializedAsync<FirmwareReleaseDescriptor>(url);
+        }
+        
+        
         #endregion
 
         #region Observations

--- a/tests/Masterloop.Plugin.Application.Tests/Rest.cs
+++ b/tests/Masterloop.Plugin.Application.Tests/Rest.cs
@@ -117,5 +117,35 @@ namespace Masterloop.Plugin.Application.Tests
             var result = await GetMCSAPI().CreatePersistentSubscriptionWhitelistAsync(GetPersistentSubscriptionKey());
             Assert.True(result);
         }
+
+        [Fact]
+        public void GetDeviceTemplateFirmwareVariants()
+        {
+            var variants = GetMCSAPI().GetDeviceTemplateFirmwareVariants(GetTID());
+            Assert.True(variants.Length == 2);
+        }
+
+        [Fact]
+        public async void GetDeviceTemplateFirmwareVariantsAsync()
+        {
+            var variants = await GetMCSAPI().GetDeviceTemplateFirmwareVariantsAsync(GetTID());
+            Assert.True(variants.Length == 2);
+        }
+
+        [Fact]
+        public void GetCurrentDeviceTemplateVariantFirmwareDetails()
+        {
+            var firmwareVariantId = 0;
+            var result = GetMCSAPI().GetCurrentDeviceTemplateVariantFirmwareDetails(GetTID(), firmwareVariantId);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async void GetCurrentDeviceTemplateVariantFirmwareDetailsAsync()
+        {
+            var firmwareVariantId = 0;
+            var result = await GetMCSAPI().GetCurrentDeviceTemplateVariantFirmwareDetailsAsync(GetTID(), firmwareVariantId);
+            Assert.NotNull(result);
+        }
     }
 }


### PR DESCRIPTION
Added access methods for following endpoints
1. GET api/templates/{TID}/firmware/variants
2. GET api/templates/{TID}/firmware/{variant_id}/current