### PR TITLE
add variant endpoints to IMasterloopServerConnection

### DIFF
--- a/src/Masterloop.Plugin.Application/IMasterloopServerConnection.cs
+++ b/src/Masterloop.Plugin.Application/IMasterloopServerConnection.cs
@@ -31,6 +31,7 @@ namespace Masterloop.Plugin.Application
         bool CreateTemplate(int tenantId, DeviceTemplate template);
 
         // Devices
+        Devicelet[] GetDevicelets(bool includeDetails = false);
         Device[] GetDevices(bool includeMetadata);
         Task<Device[]> GetDevicesAsync(bool includeMetadata);
         DetailedDevice[] GetDevices(bool includeMetadata, bool includeDetails);
@@ -49,6 +50,10 @@ namespace Masterloop.Plugin.Application
         Task<DateTime?> GetLatestLoginTimestampAsync(string MID);
         FirmwareReleaseDescriptor GetCurrentDeviceTemplateFirmwareDetails(string TID);
         Task<FirmwareReleaseDescriptor> GetCurrentDeviceTemplateFirmwareDetailsAsync(string TID);
+        FirmwareVariant[] GetDeviceTemplateFirmwareVariants(string TID);
+        Task<FirmwareVariant[]> GetDeviceTemplateFirmwareVariantsAsync(string TID);
+        FirmwareReleaseDescriptor GetCurrentDeviceTemplateVariantFirmwareDetails(string TID, int firmwareVariantId);
+        Task<FirmwareReleaseDescriptor> GetCurrentDeviceTemplateVariantFirmwareDetailsAsync(string TID, int firmwareVariantId);
 
         // Observations
         Observation GetCurrentObservation(string MID, int observationId, DataType dataType);
@@ -113,5 +118,6 @@ namespace Masterloop.Plugin.Application
         // Connectivity
         bool CanPing();
         Task<bool> CanPingAsync();
+
     }
 }

--- a/tests/Masterloop.Plugin.Application.Tests/ApplicationBase.cs
+++ b/tests/Masterloop.Plugin.Application.Tests/ApplicationBase.cs
@@ -17,7 +17,7 @@ namespace Masterloop.Plugin.Application.Tests
             return _config;
         }
 
-        protected static MasterloopServerConnection GetMCSAPI()
+        protected static IMasterloopServerConnection GetMCSAPI()
         {
             IConfiguration config = GetConfig();
             return new MasterloopServerConnection(config["Hostname"], config["Username"], config["Password"], Boolean.Parse(config["UseHTTPS"]));
@@ -25,7 +25,7 @@ namespace Masterloop.Plugin.Application.Tests
 
         protected static MasterloopLiveConnection GetMCSLiveTemporary()
         {
-            MasterloopServerConnection mcs = GetMCSAPI();
+            var mcs = GetMCSAPI();
             LiveAppRequest lar = new LiveAppRequest()
             {
                 MID = GetMID(),
@@ -40,7 +40,7 @@ namespace Masterloop.Plugin.Application.Tests
 
         protected static MasterloopLiveConnection GetMCSPersistentConnection()
         {
-            MasterloopServerConnection mcs = GetMCSAPI();
+            var mcs = GetMCSAPI();
             string subscriptionKey = GetPersistentSubscriptionKey();
             mcs.DeleteLivePersistentSubscription(subscriptionKey);
             LivePersistentSubscriptionRequest request = new LivePersistentSubscriptionRequest()

--- a/tests/Masterloop.Plugin.Application.Tests/Rest.cs
+++ b/tests/Masterloop.Plugin.Application.Tests/Rest.cs
@@ -74,7 +74,7 @@ namespace Masterloop.Plugin.Application.Tests
                     new CommandArgument() { Id = MLTEST.Constants.Commands.PollSingleArguments.ObsId, Value = "4" }
                 }
             };
-            MasterloopServerConnection mcs = GetMCSAPI();
+            var mcs = GetMCSAPI();
             mcs.Metadata = new ApplicationMetadata()
             {
                 Application = "Tests.ServerConnection",


### PR DESCRIPTION
1. add the newly created variant methods to `IMasterloopServerConnection` interface
2. update the test project to use the `IMasterloopServerConnection` interface so that tests will help identify missing endpoints from interface