### PR TITLE
Add HttpClient to send http requests with feature toggle

### DIFF
--- a/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
+++ b/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
@@ -10,6 +10,9 @@ namespace Masterloop.Plugin.Application
     public class ExtendedHttpClient
     {
         private const int DefaultTimeoutInSeconds = 30;
+        private const string OriginAddressHeader = "OriginAddress";
+        private const string OriginApplicationHeader = "OriginApplication";
+        private const string OriginReferenceHeader = "OriginReference";
 
         private readonly HttpClient _httpClient;
 
@@ -24,7 +27,6 @@ namespace Masterloop.Plugin.Application
             StatusCode = HttpStatusCode.Unused;
             StatusDescription = string.Empty;
 
-            _httpClient = new HttpClient();
             var httpClientHandler = new HttpClientHandler
             {
                 AutomaticDecompression = useCompression ? DecompressionMethods.GZip : DecompressionMethods.None
@@ -66,18 +68,18 @@ namespace Masterloop.Plugin.Application
             if (applicationMetadata == null)
                 return;
 
-            _httpClient.DefaultRequestHeaders.Remove("OriginApplication");
-            _httpClient.DefaultRequestHeaders.Remove("OriginAddress");
-            _httpClient.DefaultRequestHeaders.Remove("OriginReference");
+            _httpClient.DefaultRequestHeaders.Remove(OriginApplicationHeader);
+            _httpClient.DefaultRequestHeaders.Remove(OriginAddressHeader);
+            _httpClient.DefaultRequestHeaders.Remove(OriginReferenceHeader);
 
             if (!string.IsNullOrEmpty(applicationMetadata.Application))
-                _httpClient.DefaultRequestHeaders.Add("OriginApplication", applicationMetadata.Application);
+                _httpClient.DefaultRequestHeaders.Add(OriginApplicationHeader, applicationMetadata.Application);
 
             if (!string.IsNullOrEmpty(OriginAddress))
-                _httpClient.DefaultRequestHeaders.Add("OriginAddress", OriginAddress);
+                _httpClient.DefaultRequestHeaders.Add(OriginAddressHeader, OriginAddress);
 
             if (!string.IsNullOrEmpty(applicationMetadata.Reference))
-                _httpClient.DefaultRequestHeaders.Add("OriginReference", applicationMetadata.Reference);
+                _httpClient.DefaultRequestHeaders.Add(OriginReferenceHeader, applicationMetadata.Reference);
         }
 
         public async Task<HttpStringResponse> DownloadStringAsync(string url, string accept)

--- a/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
+++ b/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Masterloop.Plugin.Application
+{
+    public class ExtendedHttpClient
+    {
+        private const int DefaultTimeoutInSeconds = 30;
+
+        private readonly HttpClient _httpClient;
+
+        public ExtendedHttpClient(string username, string password, bool useCompression, string originAddress,
+            ApplicationMetadata applicationMetadata)
+        {
+            Username = username;
+            Password = password;
+            UseCompression = useCompression;
+            OriginAddress = originAddress;
+
+            StatusCode = HttpStatusCode.Unused;
+            StatusDescription = string.Empty;
+
+            _httpClient = new HttpClient();
+            var httpClientHandler = new HttpClientHandler
+            {
+                AutomaticDecompression = useCompression ? DecompressionMethods.GZip : DecompressionMethods.None
+            };
+
+            _httpClient = new HttpClient(httpClientHandler);
+            if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+            {
+                //request.Credentials = new NetworkCredential(this.Username, this.Password);
+                var authInfo = $"{Username}:{Password}";
+                _httpClient.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Basic", Base64Encode(authInfo));
+            }
+
+            SetMetaData(applicationMetadata);
+            SetTimeout(DefaultTimeoutInSeconds);
+            //client.ReadWriteTimeout = Timeout * 1000;
+        }
+
+        public string Username { get; }
+
+        public string Password { get; }
+
+        public HttpStatusCode StatusCode { get; set; }
+
+        public string StatusDescription { get; set; }
+
+        public string OriginAddress { get; }
+
+        public bool UseCompression { get; }
+
+        public void SetTimeout(int timeInSeconds)
+        {
+            _httpClient.Timeout = TimeSpan.FromSeconds(timeInSeconds);
+        }
+
+        public void SetMetaData(ApplicationMetadata applicationMetadata)
+        {
+            if (applicationMetadata == null)
+                return;
+
+            _httpClient.DefaultRequestHeaders.Remove("OriginApplication");
+            _httpClient.DefaultRequestHeaders.Remove("OriginAddress");
+            _httpClient.DefaultRequestHeaders.Remove("OriginReference");
+
+            if (!string.IsNullOrEmpty(applicationMetadata.Application))
+                _httpClient.DefaultRequestHeaders.Add("OriginApplication", applicationMetadata.Application);
+
+            if (!string.IsNullOrEmpty(OriginAddress))
+                _httpClient.DefaultRequestHeaders.Add("OriginAddress", OriginAddress);
+
+            if (!string.IsNullOrEmpty(applicationMetadata.Reference))
+                _httpClient.DefaultRequestHeaders.Add("OriginReference", applicationMetadata.Reference);
+        }
+
+        public async Task<HttpStringResponse> DownloadStringAsync(string url, string accept)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+
+            var response = await _httpClient.SendAsync(request);
+            if (response == null)
+                return null;
+
+            StatusCode = response.StatusCode;
+            StatusDescription = response.ReasonPhrase;
+
+            return new HttpStringResponse(response.StatusCode, response.ReasonPhrase,
+                response.IsSuccessStatusCode ? await response.Content?.ReadAsStringAsync() : null);
+        }
+
+        public async Task<HttpByteResponse> DownloadBytesAsync(string url, string accept)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+
+            var response = await _httpClient.SendAsync(request);
+            if (response == null)
+                return null;
+
+            StatusCode = response.StatusCode;
+            StatusDescription = response.ReasonPhrase;
+
+            return new HttpByteResponse(response.StatusCode, response.ReasonPhrase,
+                response.IsSuccessStatusCode ? await response.Content?.ReadAsByteArrayAsync() : null);
+        }
+
+        public async Task<HttpStringResponse> UploadStringAsync(string url, string body, string accept,
+            string contentType)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(body, Encoding.UTF8, contentType)
+            };
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+
+            var response = await _httpClient.SendAsync(request);
+            if (response == null)
+                return null;
+
+            StatusCode = response.StatusCode;
+            StatusDescription = response.ReasonPhrase;
+
+            return new HttpStringResponse(response.StatusCode, response.ReasonPhrase,
+                response.IsSuccessStatusCode ? await response.Content?.ReadAsStringAsync() : null);
+        }
+
+        public async Task<HttpStringResponse> DeleteAsync(string url)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Delete, url);
+
+            var response = await _httpClient.SendAsync(request);
+            if (response == null)
+                return null;
+
+            StatusCode = response.StatusCode;
+            StatusDescription = response.ReasonPhrase;
+
+            return new HttpStringResponse(response.StatusCode, response.ReasonPhrase,
+                response.IsSuccessStatusCode ? await response.Content?.ReadAsStringAsync() : null);
+        }
+
+        private static string Base64Encode(string textToEncode)
+        {
+            return Convert.ToBase64String(Encoding.Default.GetBytes(textToEncode));
+        }
+    }
+}

--- a/src/Masterloop.Plugin.Application/HttpByteResponse.cs
+++ b/src/Masterloop.Plugin.Application/HttpByteResponse.cs
@@ -1,0 +1,18 @@
+﻿using System.Net;
+
+namespace Masterloop.Plugin.Application
+{
+    public class HttpByteResponse
+    {
+        public HttpByteResponse(HttpStatusCode statusCode, string statusDescription, byte[] content)
+        {
+            Content = content;
+            StatusCode = statusCode;
+            StatusDescription = statusDescription;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+        public string StatusDescription { get; }
+        public byte[] Content { get; }
+    }
+}

--- a/src/Masterloop.Plugin.Application/HttpStringResponse.cs
+++ b/src/Masterloop.Plugin.Application/HttpStringResponse.cs
@@ -1,0 +1,18 @@
+﻿using System.Net;
+
+namespace Masterloop.Plugin.Application
+{
+    public class HttpStringResponse
+    {
+        public HttpStringResponse(HttpStatusCode statusCode, string statusDescription, string content)
+        {
+            Content = content;
+            StatusCode = statusCode;
+            StatusDescription = statusDescription;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+        public string StatusDescription { get; }
+        public string Content { get; }
+    }
+}

--- a/src/Masterloop.Plugin.Application/IMasterloopServerConnection.cs
+++ b/src/Masterloop.Plugin.Application/IMasterloopServerConnection.cs
@@ -19,6 +19,7 @@ namespace Masterloop.Plugin.Application
         int Timeout { get; set; }
         bool UseCompression { get; set; }
         ApplicationMetadata Metadata { get; set; }
+        bool UseHttpClientInsteadOfWebRequests { get; set; }
 
         // State
         string LastErrorMessage { get; set; }

--- a/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
+++ b/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
@@ -1266,25 +1266,104 @@ namespace Masterloop.Plugin.Application
         private Tuple<bool, string> GetString(string addressExtension, string accept = DefaultAcceptHeader)
         {
             if (UseHttpClientInsteadOfWebRequests)
-                return GetStringHttpClientAsync(addressExtension, accept).Result;
-
-            Tuple<bool, byte[]> result = GetBytes(addressExtension, accept);
-            if (result.Item1 && result.Item2 != null)
             {
-                return new Tuple<bool, string>(result.Item1, Encoding.UTF8.GetString(result.Item2));
+                return GetStringUsingHttpClientAsync(addressExtension, accept).Result;
             }
             else
             {
-                return new Tuple<bool, string>(result.Item1, string.Empty);
+                return GetStringUsingWebRequest(addressExtension, accept);
             }
         }
 
         private async Task<Tuple<bool, string>> GetStringAsync(string addressExtension, string accept = DefaultAcceptHeader)
         {
             if (UseHttpClientInsteadOfWebRequests)
-                return await GetStringHttpClientAsync(addressExtension, accept);
+            {
+                return await GetStringUsingHttpClientAsync(addressExtension, accept);
+            }
+            else
+            {
+                return await GetStringUsingWebRequestAsync(addressExtension, accept);
+            }
+        }
 
-            Tuple<bool, byte[]> result = await GetBytesAsync(addressExtension, accept);
+        private Tuple<bool, byte[]> GetBytes(string addressExtension, string accept = DefaultAcceptHeader)
+        {
+            if (UseHttpClientInsteadOfWebRequests)
+            {
+                return GetBytesUsingHttpClientAsync(addressExtension, accept).Result;
+            }
+            else
+            {
+                return GetBytesUsingWebRequest(addressExtension, accept);
+            }
+        }
+
+        private async Task<Tuple<bool, byte[]>> GetBytesAsync(string addressExtension, string accept = DefaultAcceptHeader)
+        {
+            if (UseHttpClientInsteadOfWebRequests)
+            {
+                return await GetBytesUsingHttpClientAsync(addressExtension, accept);
+            }
+            else
+            {
+                return await GetBytesUsingWebRequestAsync(addressExtension, accept);
+            }
+        }
+
+        private Tuple<bool, string> Post(string addressExtension, string body, string contentType = DefaultContentType)
+        {
+            if (UseHttpClientInsteadOfWebRequests)
+            {
+                return PostUsingHttpClientAsync(addressExtension, body, DefaultAcceptHeader, contentType).Result;
+            }
+            else
+            {
+                return PostUsingWebRequest(addressExtension, body, contentType);
+            }
+        }
+
+        private async Task<Tuple<bool, string>> PostAsync(string addressExtension, string body, string contentType = DefaultContentType)
+        {
+            if (UseHttpClientInsteadOfWebRequests)
+            {
+                return await PostUsingHttpClientAsync(addressExtension, body, DefaultAcceptHeader, contentType);
+            }
+            else
+            {
+                return await PostUsingWebRequestAsync(addressExtension, body, contentType);
+            }
+        }
+
+        private Tuple<bool, string> Delete(string addressExtension)
+        {
+            if (UseHttpClientInsteadOfWebRequests)
+            {
+                return DeleteUsingHttpClientAsync(addressExtension).Result;
+            }
+            else
+            {
+                return DeleteUsingWebRequest(addressExtension);
+            }
+        }
+
+        private async Task<Tuple<bool, string>> DeleteAsync(string addressExtension)
+        {
+            if (UseHttpClientInsteadOfWebRequests)
+            {
+                return await DeleteUsingHttpClientAsync(addressExtension);
+            }
+            else
+            {
+                return await DeleteUsingWebRequestAsync(addressExtension);
+            }
+        }
+
+        #region Http methods using WebRequests
+
+        private Tuple<bool, string> GetStringUsingWebRequest(string addressExtension, string accept)
+        {
+            var result = GetBytes(addressExtension, accept);
             if (result.Item1 && result.Item2 != null)
             {
                 return new Tuple<bool, string>(result.Item1, Encoding.UTF8.GetString(result.Item2));
@@ -1295,11 +1374,21 @@ namespace Masterloop.Plugin.Application
             }
         }
 
-        private Tuple<bool, byte[]> GetBytes(string addressExtension, string accept = DefaultAcceptHeader)
+        private async Task<Tuple<bool, string>> GetStringUsingWebRequestAsync(string addressExtension, string accept)
         {
-            if (UseHttpClientInsteadOfWebRequests)
-                return GetBytesHttpClientAsync(addressExtension, accept).Result;
+            var result = await GetBytesAsync(addressExtension, accept);
+            if (result.Item1 && result.Item2 != null)
+            {
+                return new Tuple<bool, string>(result.Item1, Encoding.UTF8.GetString(result.Item2));
+            }
+            else
+            {
+                return new Tuple<bool, string>(result.Item1, string.Empty);
+            }
+        }
 
+        private Tuple<bool, byte[]> GetBytesUsingWebRequest(string addressExtension, string accept)
+        {
             var webClient = new ExtendedWebClient();
             webClient.Accept = accept;
             webClient.Username = _username;
@@ -1308,8 +1397,8 @@ namespace Masterloop.Plugin.Application
             webClient.Metadata = this.Metadata;
             webClient.OriginAddress = _localAddress;
             webClient.UseCompression = this.UseCompression;
-            string url = _baseAddress + addressExtension;
-            bool success = false;
+            var url = _baseAddress + addressExtension;
+            var success = false;
             byte[] result = null;
             try
             {
@@ -1343,15 +1432,13 @@ namespace Masterloop.Plugin.Application
                 LastHttpStatusCode = webClient.StatusCode;
                 LastErrorMessage = e.Message;
             }
+
             return new Tuple<bool, byte[]>(success, result);
         }
 
-        private async Task<Tuple<bool, byte[]>> GetBytesAsync(string addressExtension, string accept = DefaultAcceptHeader)
+        private async Task<Tuple<bool, byte[]>> GetBytesUsingWebRequestAsync(string addressExtension, string accept)
         {
-            if (UseHttpClientInsteadOfWebRequests)
-                return await GetBytesHttpClientAsync(addressExtension, accept);
-
-            ExtendedWebClient webClient = new ExtendedWebClient();
+            var webClient = new ExtendedWebClient();
             webClient.Accept = accept;
             webClient.Username = _username;
             webClient.Password = _password;
@@ -1359,8 +1446,8 @@ namespace Masterloop.Plugin.Application
             webClient.Metadata = this.Metadata;
             webClient.OriginAddress = _localAddress;
             webClient.UseCompression = this.UseCompression;
-            string url = _baseAddress + addressExtension;
-            bool success = false;
+            var url = _baseAddress + addressExtension;
+            var success = false;
             byte[] result = null;
             try
             {
@@ -1394,15 +1481,13 @@ namespace Masterloop.Plugin.Application
                 LastHttpStatusCode = webClient.StatusCode;
                 LastErrorMessage = e.Message;
             }
+
             return new Tuple<bool, byte[]>(success, result);
         }
 
-        private Tuple<bool, string> Post(string addressExtension, string body, string contentType = DefaultContentType)
+        private Tuple<bool, string> PostUsingWebRequest(string addressExtension, string body, string contentType)
         {
-            if (UseHttpClientInsteadOfWebRequests)
-                return PostHttpClientAsync(addressExtension, body, DefaultAcceptHeader, contentType).Result;
-
-            ExtendedWebClient webClient = new ExtendedWebClient();
+            var webClient = new ExtendedWebClient();
             webClient.ContentType = contentType;
             webClient.Accept = DefaultAcceptHeader;
             webClient.Username = _username;
@@ -1411,9 +1496,9 @@ namespace Masterloop.Plugin.Application
             webClient.Metadata = this.Metadata;
             webClient.OriginAddress = _localAddress;
             webClient.UseCompression = this.UseCompression;
-            string url = _baseAddress + addressExtension;
-            string result = string.Empty;
-            bool success = false;
+            var url = _baseAddress + addressExtension;
+            var result = string.Empty;
+            var success = false;
             try
             {
                 result = webClient.UploadString(url, body);
@@ -1446,15 +1531,13 @@ namespace Masterloop.Plugin.Application
                 LastHttpStatusCode = webClient.StatusCode;
                 LastErrorMessage = e.Message;
             }
+
             return new Tuple<bool, string>(success, result);
         }
 
-        private async Task<Tuple<bool, string>> PostAsync(string addressExtension, string body, string contentType = DefaultContentType)
+        private async Task<Tuple<bool, string>> PostUsingWebRequestAsync(string addressExtension, string body, string contentType)
         {
-            if (UseHttpClientInsteadOfWebRequests)
-                return await PostHttpClientAsync(addressExtension, body, DefaultAcceptHeader, contentType);
-
-            ExtendedWebClient webClient = new ExtendedWebClient();
+            var webClient = new ExtendedWebClient();
             webClient.ContentType = contentType;
             webClient.Accept = DefaultAcceptHeader;
             webClient.Username = _username;
@@ -1463,9 +1546,9 @@ namespace Masterloop.Plugin.Application
             webClient.Metadata = this.Metadata;
             webClient.OriginAddress = _localAddress;
             webClient.UseCompression = this.UseCompression;
-            string url = _baseAddress + addressExtension;
-            string result = string.Empty;
-            bool success = false;
+            var url = _baseAddress + addressExtension;
+            var result = string.Empty;
+            var success = false;
             try
             {
                 result = await webClient.UploadStringAsync(url, body);
@@ -1498,23 +1581,21 @@ namespace Masterloop.Plugin.Application
                 LastHttpStatusCode = webClient.StatusCode;
                 LastErrorMessage = e.Message;
             }
+
             return new Tuple<bool, string>(success, result);
         }
 
-        private Tuple<bool, string> Delete(string addressExtension)
+        private Tuple<bool, string> DeleteUsingWebRequest(string addressExtension)
         {
-            if (UseHttpClientInsteadOfWebRequests)
-                return DeleteHttpClientAsync(addressExtension).Result;
-
-            ExtendedWebClient webClient = new ExtendedWebClient();
+            var webClient = new ExtendedWebClient();
             webClient.Username = _username;
             webClient.Password = _password;
             webClient.Timeout = Timeout;
             webClient.Metadata = this.Metadata;
             webClient.OriginAddress = _localAddress;
             webClient.UseCompression = this.UseCompression;
-            string url = _baseAddress + addressExtension;
-            string result = string.Empty;
+            var url = _baseAddress + addressExtension;
+            var result = string.Empty;
             try
             {
                 result = webClient.Delete(url);
@@ -1550,20 +1631,17 @@ namespace Masterloop.Plugin.Application
             return new Tuple<bool, string>(false, result);
         }
 
-        private async Task<Tuple<bool, string>> DeleteAsync(string addressExtension)
+        private async Task<Tuple<bool, string>> DeleteUsingWebRequestAsync(string addressExtension)
         {
-            if (UseHttpClientInsteadOfWebRequests)
-                return await DeleteHttpClientAsync(addressExtension);
-
-            ExtendedWebClient webClient = new ExtendedWebClient();
+            var webClient = new ExtendedWebClient();
             webClient.Username = _username;
             webClient.Password = _password;
             webClient.Timeout = Timeout;
             webClient.Metadata = this.Metadata;
             webClient.OriginAddress = _localAddress;
             webClient.UseCompression = this.UseCompression;
-            string url = _baseAddress + addressExtension;
-            string result = string.Empty;
+            var url = _baseAddress + addressExtension;
+            var result = string.Empty;
             try
             {
                 result = await webClient.DeleteAsync(url);
@@ -1591,9 +1669,11 @@ namespace Masterloop.Plugin.Application
             return new Tuple<bool, string>(false, result);
         }
 
+        #endregion
+
         #region Http methods using HttpClient
 
-        private async Task<Tuple<bool, string>> GetStringHttpClientAsync(string addressExtension, string accept = DefaultAcceptHeader)
+        private async Task<Tuple<bool, string>> GetStringUsingHttpClientAsync(string addressExtension, string accept = DefaultAcceptHeader)
         {
             var url = _baseAddress + addressExtension;
             var success = false;
@@ -1622,7 +1702,7 @@ namespace Masterloop.Plugin.Application
             return new Tuple<bool, string>(success, result);
         }
 
-        private async Task<Tuple<bool, byte[]>> GetBytesHttpClientAsync(string addressExtension, string accept = DefaultAcceptHeader)
+        private async Task<Tuple<bool, byte[]>> GetBytesUsingHttpClientAsync(string addressExtension, string accept = DefaultAcceptHeader)
         {
             var url = _baseAddress + addressExtension;
             var success = false;
@@ -1651,7 +1731,7 @@ namespace Masterloop.Plugin.Application
             return new Tuple<bool, byte[]>(success, result);
         }
 
-        private async Task<Tuple<bool, string>> PostHttpClientAsync(string addressExtension, string body, string accept = DefaultAcceptHeader, string contentType = DefaultContentType)
+        private async Task<Tuple<bool, string>> PostUsingHttpClientAsync(string addressExtension, string body, string accept = DefaultAcceptHeader, string contentType = DefaultContentType)
         {
             var url = _baseAddress + addressExtension;
             var success = false;
@@ -1680,7 +1760,7 @@ namespace Masterloop.Plugin.Application
             return new Tuple<bool, string>(success, result);
         }
 
-        private async Task<Tuple<bool, string>> DeleteHttpClientAsync(string addressExtension)
+        private async Task<Tuple<bool, string>> DeleteUsingHttpClientAsync(string addressExtension)
         {
             var url = _baseAddress + addressExtension;
             var success = false;


### PR DESCRIPTION
The application plugin is currently using `HttpWebRequest` to send http requests to Masterloop REST API. This method is now outdated and we should use `HttpClient` to manage all the requests.

The change also added a toggle option to switch between `HttpWebRequest` and `HttpClient`. With the `HttpClient` implementation the subsequent requests sent to the REST API will take much less time within the same `IMasterloopServerConnection` scope.