### PR TITLE
Http client improvements

### DIFF
--- a/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
+++ b/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
@@ -16,8 +16,7 @@ namespace Masterloop.Plugin.Application
 
         private readonly HttpClient _httpClient;
 
-        public ExtendedHttpClient(string username, string password, bool useCompression, string originAddress,
-            ApplicationMetadata applicationMetadata)
+        public ExtendedHttpClient(string username, string password, bool useCompression, string originAddress, ApplicationMetadata applicationMetadata, HttpClient httpClient)
         {
             Username = username;
             Password = password;
@@ -27,12 +26,15 @@ namespace Masterloop.Plugin.Application
             StatusCode = HttpStatusCode.Unused;
             StatusDescription = string.Empty;
 
-            var httpClientHandler = new HttpClientHandler
-            {
-                AutomaticDecompression = useCompression ? DecompressionMethods.GZip : DecompressionMethods.None
-            };
 
-            _httpClient = new HttpClient(httpClientHandler);
+            // TODO: Check how to enable compression
+            _httpClient = httpClient;
+            //var httpClientHandler = new HttpClientHandler
+            //{
+            //    AutomaticDecompression = useCompression ? DecompressionMethods.GZip : DecompressionMethods.None
+            //};
+
+            //_httpClient = new HttpClient(httpClientHandler);
             if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
                 //request.Credentials = new NetworkCredential(this.Username, this.Password);

--- a/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
+++ b/src/Masterloop.Plugin.Application/ExtendedHttpClient.cs
@@ -26,15 +26,7 @@ namespace Masterloop.Plugin.Application
             StatusCode = HttpStatusCode.Unused;
             StatusDescription = string.Empty;
 
-
-            // TODO: Check how to enable compression
             _httpClient = httpClient;
-            //var httpClientHandler = new HttpClientHandler
-            //{
-            //    AutomaticDecompression = useCompression ? DecompressionMethods.GZip : DecompressionMethods.None
-            //};
-
-            //_httpClient = new HttpClient(httpClientHandler);
             if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
                 //request.Credentials = new NetworkCredential(this.Username, this.Password);

--- a/src/Masterloop.Plugin.Application/IMasterloopServerConnection.cs
+++ b/src/Masterloop.Plugin.Application/IMasterloopServerConnection.cs
@@ -19,7 +19,7 @@ namespace Masterloop.Plugin.Application
         int Timeout { get; set; }
         bool UseCompression { get; set; }
         ApplicationMetadata Metadata { get; set; }
-        bool UseHttpClientInsteadOfWebRequests { get; set; }
+        bool UseHttpClientInsteadOfWebRequests { get; }
 
         // State
         string LastErrorMessage { get; set; }

--- a/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
+++ b/src/Masterloop.Plugin.Application/MasterloopServerConnection.cs
@@ -31,6 +31,7 @@ namespace Masterloop.Plugin.Application
         private readonly string _password;
         private string _localAddress;
         private int _timeout;
+        private bool _useCompression;
         private ApplicationMetadata _metadata;
         private readonly ExtendedHttpClient _extendedHttpClient;
         #endregion
@@ -99,7 +100,23 @@ namespace Masterloop.Plugin.Application
         /// <summary>
         /// Use HTTP traffic compression (gzip).
         /// </summary>
-        public bool UseCompression { get; set; }
+        public bool UseCompression
+        {
+            get => _useCompression;
+            set
+            {
+                if (UseHttpClientInsteadOfWebRequests)
+                {
+                    var errorMessage =
+                        new StringBuilder(
+                            $"'{nameof(UseCompression)}' is not supported when '{nameof(UseHttpClientInsteadOfWebRequests)}' is set to true");
+                    errorMessage.AppendLine(
+                        $"In this case set the 'AutomaticDecompression' of '{nameof(HttpClientHandler)}' to desired value in the dependency injected '{nameof(HttpClient)}'");
+                    throw new Exception(errorMessage.ToString());
+                }
+                _useCompression = value;
+            }
+        }
 
         /// <summary>
         /// Application metadata used in server api interactions for improved traceability (optional).


### PR DESCRIPTION
- The previous change of using HttpClient caused a major block in releasing the EaseeCloud due to timeout/socket exhaustion. 
- This change allows to inject the HttpClient so that in developers can make use of IHttpClientFactory in asp.net core to overcome the issues with HttpClient. 
- Moreover since the HttpClient is injected, we have to set the compression before the HttpClient is injected. Therefore we should not allow setting compression via MasterloopServerConnection when a developer wants to use the HttpClient to send http requests
- The change was based on this article: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests