### PR TITLE
Deserialize http client response using response streams instead of st…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 
 # dotCover
 *.dotCover
+
+# Tests
+*.test.json

--- a/src/Masterloop.Plugin.Application/HttpByteResponse.cs
+++ b/src/Masterloop.Plugin.Application/HttpByteResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Masterloop.Plugin.Application
 {
-    public class HttpByteResponse
+    internal class HttpByteResponse
     {
         public HttpByteResponse(HttpStatusCode statusCode, string statusDescription, byte[] content)
         {

--- a/src/Masterloop.Plugin.Application/HttpStringResponse.cs
+++ b/src/Masterloop.Plugin.Application/HttpStringResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Masterloop.Plugin.Application
 {
-    public class HttpStringResponse
+    internal class HttpStringResponse
     {
         public HttpStringResponse(HttpStatusCode statusCode, string statusDescription, string content)
         {

--- a/src/Masterloop.Plugin.Application/HttpTypeResponse.cs
+++ b/src/Masterloop.Plugin.Application/HttpTypeResponse.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+
+namespace Masterloop.Plugin.Application
+{
+    internal class HttpTypeResponse<T>
+    {
+        public HttpTypeResponse(HttpStatusCode statusCode, string statusDescription)
+        {
+            StatusCode = statusCode;
+            StatusDescription = statusDescription;
+        }
+
+        public HttpTypeResponse(HttpStatusCode statusCode, string statusDescription, T content): this(statusCode, statusDescription)
+        {
+            Content = content;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+        public string StatusDescription { get; }
+        public T Content { get; }
+    }
+}

--- a/src/Masterloop.Plugin.Application/Masterloop.Plugin.Application.csproj
+++ b/src/Masterloop.Plugin.Application/Masterloop.Plugin.Application.csproj
@@ -32,5 +32,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
     <PackageReference Include="Masterloop.Core.Types" Version="6.4.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
 </Project>

--- a/tests/Masterloop.Plugin.Application.Tests/ApplicationBase.cs
+++ b/tests/Masterloop.Plugin.Application.Tests/ApplicationBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using Masterloop.Core.Types.LiveConnect;
 using Microsoft.Extensions.Configuration;
 
@@ -17,10 +18,17 @@ namespace Masterloop.Plugin.Application.Tests
             return _config;
         }
 
-        protected static IMasterloopServerConnection GetMCSAPI()
+        protected static IMasterloopServerConnection GetMCSAPI(bool useHttpClient = true)
         {
             IConfiguration config = GetConfig();
-            return new MasterloopServerConnection(config["Hostname"], config["Username"], config["Password"], Boolean.Parse(config["UseHTTPS"]));
+            if (useHttpClient)
+            {
+                return new MasterloopServerConnection(config["Hostname"], config["Username"], config["Password"], new HttpClient(), Boolean.Parse(config["UseHTTPS"]));
+            }
+            else
+            {
+                return new MasterloopServerConnection(config["Hostname"], config["Username"], config["Password"], Boolean.Parse(config["UseHTTPS"]));
+            }
         }
 
         protected static MasterloopLiveConnection GetMCSLiveTemporary()

--- a/tests/Masterloop.Plugin.Application.Tests/appsettings.test.json
+++ b/tests/Masterloop.Plugin.Application.Tests/appsettings.test.json
@@ -1,9 +1,0 @@
-﻿{
-  "Hostname": "",
-  "Username": "",
-  "Password": "",
-  "UseHTTPS": true,
-  "MID": "",
-  "TID": "",
-  "PersistentSubscriptionKey": ""
-}


### PR DESCRIPTION
The aim or this PR was to improve the memory utilization when using HttpClient to communicate with Masterloop REST API
The changes include:

- Deserialize objects using response streams in HttpClient instead of passing an intermediate string for deserialization
- Add some basic tests for the REST api

The improvements were based on this article: https://code-maze.com/using-streams-with-httpclient-to-improve-performance-and-memory-usage/